### PR TITLE
Dockerhub automated builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM resin/armv7hf-python:3.6-slim
+
+RUN [ "cross-build-start" ]
+RUN apt-get update && apt-get install -y gcc libc-dev python3-dev libffi-dev libssl-dev && rm -rf /var/lib/apt/lists/*
+RUN pip install gevent==1.2.2
+
+COPY . .
+RUN pip install -e ./
+
+EXPOSE 5557/tcp
+
+RUN [ "cross-build-end" ]
+CMD [ "xbox-rest-server" ]


### PR DESCRIPTION
This is a Dockerfile to support both ARM devices and x86. This can be build automatically using Dockerhub. See GH-14

You can use the settings below to build a new image based on the tag version.
![image](https://user-images.githubusercontent.com/343616/46537104-c0d84b80-c8b0-11e8-8bf2-e98c522a559e.png)